### PR TITLE
QC fail flag fixes for mix/max coverage

### DIFF
--- a/src/VariantBamWalker.cpp
+++ b/src/VariantBamWalker.cpp
@@ -135,16 +135,22 @@ void VariantBamWalker::subSampleWrite(SeqLib::BamRecordVector& buff, const STCov
 	  uint32_t k = __ac_Wang_hash(__ac_X31_hash_string(r.Qname().c_str()) ^ m_seed);
 	  if ((double)(k&0xffffff) / 0x1000000 <= sample_rate) { // passed the random filter
 	    write_record(r);
-
+	  } else if (m_mark_qc_fail) {
+	    r.SetQCFail(true);
+	    write_record(r);
 	  }
 	}
       // only take if reaches minimum coverage
       else if (this_cov < -max_cov) { // max_cov = -10 
-	if (m_mark_qc_fail)
+	if (m_mark_qc_fail) {
 	  r.SetQCFail(true);
-	//std::cerr << "not writing because this cov is " << this_cov << " and min cov is " << (-max_cov) << std::endl;
-      } 
-      write_record(r);
+          write_record(r);
+	} else {
+	  //std::cerr << "not writing because this cov is " << this_cov << " and min cov is " << (-max_cov) << std::endl;
+	}
+      } else {
+        write_record(r);
+      }
       
     }
   


### PR DESCRIPTION
Jeremiah;
Thanks so much for the work on setting QC fail. I was testing this and realized it was not properly setting the flag for maximum coverage cutoffs. I believe the logic was a little off in the original implementation and think this PR addresses it. Happy to discuss more if anything here continues to look off.

- sets QC fail for maximum coverage cutoff
- Ensures record written in correct condition for min coverage cutoff
- Avoid extra write_record that duplicates and writes extra records
  during downsampling

Follow up to walaj/VariantBam#9